### PR TITLE
realized search using reverse index

### DIFF
--- a/go_lesson_04/engine/cmd/engine/main.go
+++ b/go_lesson_04/engine/cmd/engine/main.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"gosearch/pkg/crawler/spider"
+	"gosearch/pkg/index"
+)
+
+func main() {
+	urls := []string{"https://habr.com/", "https://www.cnews.ru/"}
+	const depth int = 2
+	var spider = spider.New()
+
+	fmt.Printf("Today we have %d sites to scan!\n", len(urls))
+	storage := index.Fill(spider, urls, depth)
+
+	// получаем значение поисковой строки из аргумента
+	// и проставляем флаг, если строка была получена именно таким способом
+	var recvCmdArg = false
+	search := parseSearchPhrase()
+	if search != "" {
+		recvCmdArg = true
+	}
+
+	for {
+		// если поисковая строка не была получена из аргумента
+		// или была указана пустой - запрашиваем ее у пользователя
+		if search == "" {
+			fmt.Print("Enter search phrase and press ENTER to search ")
+			fmt.Print("(or just press ENTER to exit): ")
+			fmt.Scanln(&search)
+
+			// если пользователь ничего не указал - выходим из приложения
+			if search == "" {
+				break
+			}
+		}
+
+		fmt.Print(storage.Find(search))
+
+		// если поисковая строка была получена из аргумента,
+		// то дальнейший интерактив не требуется - выходим из приложения
+		if recvCmdArg {
+			break
+		}
+
+		// сбрасываем значение поисковой строки
+		// для выдачи запроса на ее ввод в следующей итерации
+		search = ""
+	}
+}
+
+// parseSearchPhrase возвращает поисковое значение, переданное при запуске приложения
+func parseSearchPhrase() string {
+	searchPtr := flag.String("search", "", "word/phrase to search in page title")
+	flag.Parse()
+
+	if *searchPtr != "" {
+		fmt.Printf("Your search phrase is: %s\n", *searchPtr)
+	}
+
+	return *searchPtr
+}

--- a/go_lesson_04/index/pkg/index/index.go
+++ b/go_lesson_04/index/pkg/index/index.go
@@ -1,0 +1,140 @@
+// index реализует индексирование загруженных web-страниц
+// и предоставляет функционал поиска по данном индексу
+
+package index
+
+import (
+	"errors"
+	"fmt"
+	"gosearch/pkg/crawler"
+	"math/rand"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Storage - структура для хранения массива документов и обратного индекса
+// (словаря, где ключом является слово из Title, а значением - ID документа)
+type Storage struct {
+	Docs    []crawler.Document
+	Reverse map[string][]int
+}
+
+// Find формирует отчет о результатах поиска указанного слова
+// (содержит ID и Title документа, в которых было найдено указанное слово)
+func (s *Storage) Find(word string) string {
+	docs, found := s.Reverse[word]
+	if !found {
+		return "Nothing.\n"
+	}
+
+	var report string = ""
+	for _, id := range docs {
+		doc, err := s.getDocBin(id)
+		if err != nil {
+			continue
+		}
+
+		report += "[" + strconv.Itoa(doc.ID) + "] " + doc.Title + "\n"
+	}
+
+	return report
+}
+
+// Fill загружает содержимое указанных web-страниц и индексирует полученные данные
+func Fill(scn crawler.Scanner, urls []string, depth int) *Storage {
+	var storage = Storage{
+		Docs:    make([]crawler.Document, 0),
+		Reverse: make(map[string][]int),
+	}
+
+	var scanData = make([]crawler.Document, 0)
+
+	for i, url := range urls {
+		fmt.Printf("Scanning URL #%d: %s\n", i+1, url)
+
+		data, err := scn.Scan(url, depth)
+		if err != nil {
+			continue
+		}
+
+		scanData = append(scanData, data...)
+	}
+
+	storage.append(scanData)
+
+	return &storage
+}
+
+func (s *Storage) append(data []crawler.Document) {
+	// инициализируем генератор случайных чисел
+	seed := rand.NewSource(time.Now().UnixNano())
+	rgen := rand.New(seed)
+
+	// формируем массив случайных ID для новой порции документов
+	var newCount = len(data)
+	var existCount = len(s.Docs)
+	var id int
+	deltas := rgen.Perm(newCount)
+
+	for i, doc := range data {
+		id = existCount + 1 + deltas[i]
+
+		// присваиваем документу случайный ID и добавляем его в массив
+		doc.ID = id
+		s.Docs = append(s.Docs, doc)
+
+		// добавляем в обратный индекс новые слова
+		s.addNewWords(doc)
+	}
+
+	// сортируем массив документов
+	sort.Slice(s.Docs, func(i, j int) bool { return s.Docs[i].ID < s.Docs[j].ID })
+}
+
+// addNewWords добавляет в словарь новые слова в нижнем регистре
+func (s *Storage) addNewWords(doc crawler.Document) {
+	wordPattern := regexp.MustCompile("[\\p{L}\\d]+")
+	var titleLow = strings.ToLower(doc.Title)
+
+	words := wordPattern.FindAllString(titleLow, -1)
+	if words == nil {
+		return
+	}
+
+	uniqueWords := make(map[string]bool)
+
+	for _, word := range words {
+		// исключаем повторную обработку слов по тому же документу
+		if _, duplicate := uniqueWords[word]; duplicate {
+			continue
+		}
+		uniqueWords[word] = true
+
+		// добавляем документ в список для данного слова
+		s.Reverse[word] = append(s.Reverse[word], doc.ID)
+	}
+}
+
+// getDocBin возвращает указатель на документ с указанным ID (бинарный поиск)
+func (s *Storage) getDocBin(id int) (*crawler.Document, error) {
+	i := sort.Search(len(s.Docs), func(i int) bool { return s.Docs[i].ID >= id })
+	if i < len(s.Docs) && s.Docs[i].ID == id {
+		return &s.Docs[i], nil
+	}
+
+	return nil, errors.New("not found")
+}
+
+// getDoc возвращает указатель на документ с указанным ID (простой перебор массива)
+func (s *Storage) getDoc(id int) (*crawler.Document, error) {
+	for _, doc := range s.Docs {
+		if doc.ID == id {
+			return &doc, nil
+		}
+	}
+
+	return nil, errors.New("not found")
+}

--- a/go_lesson_04/index/pkg/index/index.go
+++ b/go_lesson_04/index/pkg/index/index.go
@@ -25,7 +25,7 @@ type Storage struct {
 // Find формирует отчет о результатах поиска указанного слова
 // (содержит ID и Title документа, в которых было найдено указанное слово)
 func (s *Storage) Find(word string) string {
-	docs, found := s.Reverse[word]
+	docs, found := s.Reverse[strings.ToLower(word)]
 	if !found {
 		return "Nothing.\n"
 	}

--- a/go_lesson_04/index/pkg/index/index_test.go
+++ b/go_lesson_04/index/pkg/index/index_test.go
@@ -43,33 +43,13 @@ func TestStorage_addNewWords(t *testing.T) {
 	var doc = crawler.Document{
 		ID:    1,
 		URL:   "https://site.com",
-		Title: "Слово1 Слово2 Слово1 Слово3",
-	}
-
-	want := map[string][]int{
-		"cлово1": []int{1},
-		"cлово2": []int{1},
-		"cлово3": []int{1},
+		Title: "Слово1 Слово2 Слово1",
 	}
 
 	store.addNewWords(doc)
 	got := store.Reverse
 
-	if len(want) != len(got) {
+	if len(got) != 2 {
 		t.Fatal("invalid word splitting")
-	}
-
-	for k := range want {
-		gotIds, ok := want[k]
-
-		if !ok {
-			t.Fatal("different indexes")
-		}
-
-		for i := 0; i < len(want[k]); i++ {
-			if want[k][i] != gotIds[i] {
-				t.Fatal("found duplicates")
-			}
-		}
 	}
 }

--- a/go_lesson_04/index/pkg/index/index_test.go
+++ b/go_lesson_04/index/pkg/index/index_test.go
@@ -1,0 +1,75 @@
+package index
+
+import (
+	"gosearch/pkg/crawler"
+	"reflect"
+	"testing"
+)
+
+func TestStorage_getDoc(t *testing.T) {
+	var docs = []crawler.Document{
+		{
+			ID:    1,
+			URL:   "https://yandex.ru",
+			Title: "Яндекс",
+		},
+		{
+			ID:    2,
+			URL:   "https://google.ru",
+			Title: "Google",
+		},
+	}
+
+	var store Storage
+	store.Docs = docs
+
+	var want = docs[1]
+	got, err := store.getDoc(2)
+
+	if !reflect.DeepEqual(want, *got) || err != nil {
+		t.Fatal("getDoc returned invalid result")
+	}
+
+	got, err = store.getDocBin(2)
+	if !reflect.DeepEqual(want, *got) || err != nil {
+		t.Fatal("getDocBin returned invalid result")
+	}
+}
+
+func TestStorage_addNewWords(t *testing.T) {
+	var store Storage
+	store.Reverse = make(map[string][]int)
+
+	var doc = crawler.Document{
+		ID:    1,
+		URL:   "https://site.com",
+		Title: "Слово1 Слово2 Слово1 Слово3",
+	}
+
+	want := map[string][]int{
+		"cлово1": []int{1},
+		"cлово2": []int{1},
+		"cлово3": []int{1},
+	}
+
+	store.addNewWords(doc)
+	got := store.Reverse
+
+	if len(want) != len(got) {
+		t.Fatal("invalid word splitting")
+	}
+
+	for k := range want {
+		gotIds, ok := want[k]
+
+		if !ok {
+			t.Fatal("different indexes")
+		}
+
+		for i := 0; i < len(want[k]); i++ {
+			if want[k][i] != gotIds[i] {
+				t.Fatal("found duplicates")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Взял из репозитория актуальную версию Spider. По умолчанию он проставляет документам ID = 0. Не стал менять это поведение, т.к. идентификаторы документам на мой взгляд должен проставлять Index. Соответственно реализовал в последнем заполнение ID случайными числами (так, чтобы новые документы получали ID > чем у старых, т.е. чтобы они были уникальными / не пересекались).