### PR TITLE
add cache pkg

### DIFF
--- a/go_lesson_06/gosearch/cmd/gosearch/main.go
+++ b/go_lesson_06/gosearch/cmd/gosearch/main.go
@@ -52,7 +52,6 @@ func new() *gosearch {
 		"storage": "storage.bin",
 	}
 	gs.cache = bstcache.New(gs.cacheFiles)
-	gs.engine = engine.New(gs.index, gs.storage)
 	gs.sites = []string{"https://www.ixbt.com/", "https://habr.com/"}
 	gs.depth = 2
 	return &gs
@@ -77,9 +76,7 @@ func (gs *gosearch) loadCache() {
 		log.Println(err)
 	}
 
-	gs.index = *ind
-	gs.storage = *str
-	gs.engine = engine.New(gs.index, gs.storage)
+	gs.engine = engine.New(*ind, *str)
 }
 
 // saveCache сохраняет индекс и хранилище в кэш
@@ -114,6 +111,7 @@ func (gs *gosearch) init() {
 			continue
 		}
 	}
+	gs.engine = engine.New(gs.index, gs.storage)
 }
 
 // run выполняет поиск документов

--- a/go_lesson_06/gosearch/cmd/gosearch/main.go
+++ b/go_lesson_06/gosearch/cmd/gosearch/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"gosearch/pkg/cache"
+	"gosearch/pkg/cache/bstcache"
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/crawler/spider"
+	"gosearch/pkg/engine"
+	"gosearch/pkg/index"
+	"gosearch/pkg/index/hash"
+	"gosearch/pkg/storage"
+	"gosearch/pkg/storage/bststore"
+)
+
+// Сервер Интернет-поисковика GoSearch.
+type gosearch struct {
+	engine  *engine.Service
+	scanner crawler.Interface
+	index   index.Interface
+	storage storage.Interface
+	cache   cache.Interface
+
+	cacheFiles map[string]string
+	sites      []string
+	depth      int
+}
+
+func main() {
+	server := new()
+	server.loadCache()
+	go func() {
+		server.init()
+		server.saveCache()
+	}()
+	server.searchLoop()
+}
+
+// new создаёт объект и службы сервера и возвращает указатель на него.
+func new() *gosearch {
+	gs := gosearch{}
+	gs.scanner = spider.New()
+	gs.index = hash.New()
+	gs.storage = bststore.New()
+	gs.cacheFiles = map[string]string{
+		"index":   "index.bin",
+		"storage": "storage.bin",
+	}
+	gs.cache = bstcache.New(gs.cacheFiles)
+	gs.engine = engine.New(gs.index, gs.storage)
+	gs.sites = []string{"https://www.ixbt.com/", "https://habr.com/"}
+	gs.depth = 2
+	return &gs
+}
+
+// loadCache загружает индекс и хранилище из кэша (если он есть)
+func (gs *gosearch) loadCache() {
+	_, err := os.Stat(gs.cacheFiles["index"])
+	if err != nil {
+		log.Println("Кэш не найден.")
+		return
+	}
+	_, err = os.Stat(gs.cacheFiles["storage"])
+	if err != nil {
+		log.Println("Кэш не найден.")
+		return
+	}
+
+	log.Println("Загрузка данных из кэша.")
+	ind, str, err := gs.cache.Load()
+	if err != nil {
+		log.Println(err)
+	}
+
+	gs.index = *ind
+	gs.storage = *str
+	gs.engine = engine.New(gs.index, gs.storage)
+}
+
+// saveCache сохраняет индекс и хранилище в кэш
+func (gs *gosearch) saveCache() {
+	log.Println("Сохранение данных в кэш.")
+	err := gs.cache.Create(&gs.index, &gs.storage)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// init производит сканирование сайтов и индексирование данных.
+func (gs *gosearch) init() {
+	log.Println("Сканирование сайтов.")
+	id := 0
+	for _, url := range gs.sites {
+		log.Println("Сайт:", url)
+		data, err := gs.scanner.Scan(url, gs.depth)
+		if err != nil {
+			continue
+		}
+		for i := range data {
+			data[i].ID = id
+			id++
+		}
+		log.Println("Индексирование документов.")
+		gs.index.Add(data)
+		log.Println("Сохранение документов.")
+		err = gs.storage.StoreDocs(data)
+		if err != nil {
+			log.Println("ошибка при добавлении документов в хранилище:", err)
+			continue
+		}
+	}
+}
+
+// run выполняет поиск документов
+func (gs *gosearch) searchLoop() {
+	// получаем значение поисковой строки из аргумента
+	// и проставляем флаг, если строка была получена именно таким способом
+	var fromCmd = false
+	word := parseSearchWord()
+	if word != "" {
+		fromCmd = true
+	}
+
+	for {
+		// если поисковая строка не была получена из аргумента
+		// или была указана пустой - запрашиваем ее у пользователя
+		if word == "" {
+			fmt.Print("Enter word and press ENTER: ")
+			fmt.Scanln(&word)
+			// если пользователь ничего не указал - выходим из приложения
+			if word == "" {
+				break
+			}
+		}
+
+		docs := gs.engine.Search(word)
+		text := genOutput(docs)
+		fmt.Print(text)
+
+		// если поисковая строка была получена из аргумента,
+		// то дальнейший интерактив не требуется - выходим из приложения
+		if fromCmd {
+			break
+		}
+
+		// сбрасываем значение поисковой строки
+		// для выдачи запроса на ее ввод в следующей итерации
+		word = ""
+	}
+}
+
+func genOutput(docs []crawler.Document) string {
+	if docs == nil {
+		return "Nothing.\n"
+	}
+
+	var text string = ""
+	for _, doc := range docs {
+		text += "[" + strconv.Itoa(doc.ID) + "] " + doc.Title + "\n"
+	}
+	return text
+}
+
+// parseSearchWord возвращает слово для поиска, переданное в виде флага при запуске приложения
+func parseSearchWord() string {
+	searchPtr := flag.String("search", "", "word to search in page title")
+	flag.Parse()
+	return *searchPtr
+}

--- a/go_lesson_06/gosearch/pkg/cache/bstcache/bstcache.go
+++ b/go_lesson_06/gosearch/pkg/cache/bstcache/bstcache.go
@@ -1,0 +1,88 @@
+package bstcache
+
+import (
+	"encoding/gob"
+	"os"
+
+	"gosearch/pkg/crawler"
+	"gosearch/pkg/index"
+	"gosearch/pkg/index/hash"
+	"gosearch/pkg/storage"
+	"gosearch/pkg/storage/bststore"
+)
+
+// Cacher - структура, реализующая контракт кэширующего модуля
+type Cacher struct {
+	indexFile, storageFile string
+}
+
+// New - конструктор.
+func New(cacheFiles map[string]string) *Cacher {
+	c := Cacher{
+		indexFile:   cacheFiles["index"],
+		storageFile: cacheFiles["storage"],
+	}
+	return &c
+}
+
+// Create сохраняет индекс и хранилище в файлы
+func (c *Cacher) Create(index *index.Interface, storage *storage.Interface) error {
+	indexFile, err := os.Create(c.indexFile)
+	if err != nil {
+		return err
+	}
+	defer indexFile.Close()
+	gob.Register(&hash.Index{})
+	gob.Register(&crawler.Document{})
+	enc := gob.NewEncoder(indexFile)
+	err = enc.Encode(index)
+	if err != nil {
+		return err
+	}
+
+	storageFile, err := os.Create(c.storageFile)
+	if err != nil {
+		return err
+	}
+	defer storageFile.Close()
+	gob.Register(&bststore.DB{})
+	enc = gob.NewEncoder(storageFile)
+	err = enc.Encode(storage)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Load загружает индекс и хранилище из файлов
+func (c *Cacher) Load() (*index.Interface, *storage.Interface, error) {
+	indexFile, err := os.Open(c.indexFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer indexFile.Close()
+	var indexData index.Interface
+	gob.Register(&hash.Index{})
+	gob.Register(&crawler.Document{})
+	dec := gob.NewDecoder(indexFile)
+	err = dec.Decode(&indexData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	storageFile, err := os.Open(c.storageFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer storageFile.Close()
+	var storageData storage.Interface
+	gob.Register(&bststore.DB{})
+	dec = gob.NewDecoder(storageFile)
+	err = dec.Decode(&storageData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &indexData, &storageData, nil
+}

--- a/go_lesson_06/gosearch/pkg/cache/bstcache/bstcache_test.go
+++ b/go_lesson_06/gosearch/pkg/cache/bstcache/bstcache_test.go
@@ -1,0 +1,32 @@
+package bstcache
+
+import (
+	"gosearch/pkg/index"
+	"gosearch/pkg/index/hash"
+	"gosearch/pkg/storage"
+	"gosearch/pkg/storage/bststore"
+	"reflect"
+	"testing"
+)
+
+func TestCacher_CreateAndLoad(t *testing.T) {
+	cacheFiles := map[string]string{
+		"index":   "index.bin",
+		"storage": "storage.bin",
+	}
+	cache := New(cacheFiles)
+	var index index.Interface = hash.New()
+	var storage storage.Interface = bststore.New()
+
+	err := cache.Create(&index, &storage)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	indexLoaded, _, err := cache.Load()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if !reflect.DeepEqual(index, *indexLoaded) {
+		t.Fatalf("загруженный индекс отличается от исходного")
+	}
+}

--- a/go_lesson_06/gosearch/pkg/cache/cache.go
+++ b/go_lesson_06/gosearch/pkg/cache/cache.go
@@ -1,0 +1,14 @@
+package cache
+
+// Кэш для временного хранения индекса и хранилища.
+
+import (
+	"gosearch/pkg/index"
+	"gosearch/pkg/storage"
+)
+
+// Interface определяет контракт кэширующего модуля
+type Interface interface {
+	Create(*index.Interface, *storage.Interface) error
+	Load() (*index.Interface, *storage.Interface, error)
+}


### PR DESCRIPTION
Сериализацию реализовал с помощью gob - в пакете `cache` объявил интерфейс модуля кэширования с двумя методами `Save()` и `Load()`, принимающими указатели на интерфейсы индекса и хранилища. Контракт интерфейса реализован в `bstcache` (предназначен для работы с бинарным деревом).

В main для сервера добавил методы `loadCache()` и `saveCache()`, которые обеспечивают возможность использования кэша для выдачи результатов поиска до окончания загрузки и индексирования веб-страниц.