### PR TITLE
add auth service

### DIFF
--- a/go_lesson_17/auth/cmd/auth/auth.go
+++ b/go_lesson_17/auth/cmd/auth/auth.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"auth/pkg/api"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	router := mux.NewRouter()
+	creds := initCreds()
+	secret := "auth-service-password"
+	api := api.New(router, creds, secret)
+	api.Endpoints()
+
+	http.ListenAndServe(":8000", router)
+}
+
+func initCreds() []api.UserCredential {
+	var c = []api.UserCredential{
+		{
+			Username: "user",
+			Password: "user",
+			Roles:    []string{"User"},
+		},
+		{
+			Username: "oper",
+			Password: "oper",
+			Roles:    []string{"Manager", "Backup"},
+		},
+		{
+			Username: "admin",
+			Password: "admin",
+			Roles:    []string{"Backup", "Admin"},
+		},
+	}
+	return c
+}

--- a/go_lesson_17/auth/cmd/auth/go.mod
+++ b/go_lesson_17/auth/cmd/auth/go.mod
@@ -1,0 +1,12 @@
+module auth/cmd/auth
+
+go 1.15
+
+replace auth/pkg/api => ../../pkg/api
+
+require (
+	auth/pkg/api v0.0.0-00010101000000-000000000000
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
+	github.com/gorilla/mux v1.8.0
+)

--- a/go_lesson_17/auth/pkg/api/api.go
+++ b/go_lesson_17/auth/pkg/api/api.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+)
+
+// API реализует функционал аутентификации по JWT
+type API struct {
+	router *mux.Router
+	creds  []UserCredential
+	secret string
+}
+
+// UserCredential хранит аутентификационную информацию и роли пользователя
+type UserCredential struct {
+	Username string
+	Password string
+	Roles    []string
+}
+
+// authData задает формат запроса на аутентификацию
+type authData struct {
+	Username string
+	Password string
+}
+
+// New - конструктор API
+func New(router *mux.Router, creds []UserCredential, secret string) *API {
+	api := API{
+		router: router,
+		creds:  creds,
+		secret: secret,
+	}
+	return &api
+}
+
+// Endpoints регистрирует конечные точки API
+func (api *API) Endpoints() {
+	api.router.Handle("/auth", handlers.LoggingHandler(os.Stdout, http.HandlerFunc(api.auth)))
+}
+
+func (api *API) auth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "unsupported method", http.StatusInternalServerError)
+		return
+	}
+	var data authData
+	err := json.NewDecoder(r.Body).Decode(&data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	roles, err := api.getUserRole(data.Username, data.Password)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	token, err := api.getJWT(data.Username, roles)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write([]byte("Token: " + token))
+}
+
+func (api *API) getUserRole(usr, pwd string) ([]string, error) {
+	for _, cred := range api.creds {
+		if cred.Username == usr && cred.Password == pwd {
+			return cred.Roles, nil
+		}
+	}
+	return nil, errors.New("ошибка авторизации")
+
+}
+
+func (api *API) getJWT(usr string, roles []string) (string, error) {
+	token := jwt.NewWithClaims(
+		jwt.SigningMethodHS256,
+		jwt.MapClaims{
+			"usr":   usr,
+			"nbf":   time.Now().Unix(),
+			"roles": roles,
+		})
+
+	return token.SignedString([]byte(api.secret))
+}

--- a/go_lesson_17/auth/pkg/api/api_test.go
+++ b/go_lesson_17/auth/pkg/api/api_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+var api *API
+
+func TestMain(m *testing.M) {
+	router := mux.NewRouter()
+	creds := []UserCredential{
+		{
+			Username: "user",
+			Password: "valid_password",
+			Roles:    []string{"User"},
+		},
+	}
+	secret := "secret"
+	api = New(router, creds, secret)
+	api.Endpoints()
+	os.Exit(m.Run())
+}
+
+func TestAPI_auth(t *testing.T) {
+	data := authData{
+		Username: "user",
+		Password: "valid_password",
+	}
+	payload, _ := json.Marshal(data)
+	req := httptest.NewRequest(http.MethodPost, "/auth", bytes.NewBuffer(payload))
+	rr := httptest.NewRecorder()
+	api.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Errorf("код неверен: получили %d, а хотели %d", rr.Code, http.StatusOK)
+	}
+
+	got := rr.Body.String()
+	want := "Token:"
+	if !strings.HasPrefix(got, want) {
+		t.Errorf("содержимое некорректно: получили %s, а хотели %s", got, want)
+	}
+
+	data = authData{
+		Username: "user",
+		Password: "wrong_password",
+	}
+	payload, _ = json.Marshal(data)
+	req = httptest.NewRequest(http.MethodPost, "/auth", bytes.NewBuffer(payload))
+	rr = httptest.NewRecorder()
+	api.router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("код неверен: получили %d, а хотели %d", rr.Code, http.StatusUnauthorized)
+	}
+}

--- a/go_lesson_17/auth/pkg/api/go.mod
+++ b/go_lesson_17/auth/pkg/api/go.mod
@@ -1,0 +1,9 @@
+module auth/pkg/api
+
+go 1.15
+
+require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/mux v1.8.0
+)


### PR DESCRIPTION
Не понял один момент:
`api.router.Handle("/auth", handlers.LoggingHandler(os.Stdout, http.HandlerFunc(api.auth)))`
если я регистрирую middleware-логгер таким образом (для конкретного path) - как мне задать здесь же (при регистрации) разрешенные (поддерживаемые) HTTP-методы для данного path? Из-за этого добавил проверку на POST в функцию-обработчик.

В остальном LGTM.